### PR TITLE
Set timeouts to avoid memory leaks (server+client)

### DIFF
--- a/kit/kit.go
+++ b/kit/kit.go
@@ -84,12 +84,17 @@ func (s *service) SetPostShutdownHandler(handler ShutdownHandlerFunc) {
 // graceful shutdowns are enabled and the service will wait for in-flight requests
 // when an OS interrupt is received before shutting down. This behaviour can be turned
 // off with DrainConnections function.
+
+// By default all the timeouts (ReadTimeout, WriteTimeout, IdleTimeout, ReadHeaderTimeout)
+// are set to 60s. These timeouts are set to avoid memory leaks.
 func (s *service) ListenAndServe(addr string) error {
 	srv := http.Server{
-		Addr:         addr,
-		Handler:      s.handler,
-		ReadTimeout:  60 * time.Second,
-		WriteTimeout: 60 * time.Second,
+		Addr:              addr,
+		Handler:           s.handler,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		ReadHeaderTimeout: 60 * time.Second,
 	}
 
 	stopChan := make(chan os.Signal)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -1,12 +1,11 @@
 package trace
 
 import (
+	"io"
 	"net/http"
 	"net/url"
-
-	"io"
-
 	"strings"
+	"time"
 
 	"github.com/sethgrid/pester"
 	"github.com/wrapp/gokit/env"
@@ -86,6 +85,7 @@ func (t *TraceClient) SetUserAgent(agent string) {
 func New(rIdFunc RequestIDFunc) *TraceClient {
 	client := pester.New()
 	client.Backoff = pester.LinearBackoff
+	client.Timeout = 60 * time.Second
 	client.MaxRetries = 3
 	return NewExtendedClient(rIdFunc, client)
 }


### PR DESCRIPTION
These timeouts are set to avoid memory leaks. If we dont set them and there is a request which hangs forever then it will never timeout and hence memory will be leaked.